### PR TITLE
48 connect charts to get workouts

### DIFF
--- a/frontend/app/progress/page.tsx
+++ b/frontend/app/progress/page.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useMemo, useState } from "react";
+import { getWorkouts, type Workout } from "@/lib/api";
 import PageHeader from "@/components/layout/PageHeader";
 import StatCard from "@/components/dashboard/StatCard";
 import Card from "@/components/ui/Card";
@@ -8,6 +10,72 @@ import WeeklyWorkoutsLineChart from "@/components/charts/WeeklyWorkoutsLineChart
 import WorkoutTypeBarChart from "@/components/charts/WorkoutTypeBarChart";
 
 export default function ProgressPage(){
+    const [workouts, setWorkouts] = useState<Workout[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        async function loadWorkouts(){
+            try{
+                setLoading(true);
+                setError("");
+                const data = await getWorkouts();
+                setWorkouts(data);
+            } catch(err){
+                console.error(error);
+                setError("Failed to load workout data.");
+            } finally{
+                setLoading(false);
+            }
+        }
+
+        loadWorkouts();
+    }, []);
+
+    const weeklyData = useMemo(() => {
+        const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+        const counts = days.map((day) => ({
+            day,
+            count: 0,
+        }));
+
+        workouts.forEach((workout) => {
+            const date = new Date(workout.date);
+            const dayIndex = date.getDay();
+            counts[dayIndex].count += 1;
+        });
+
+        return[
+            counts[1],
+            counts[2],
+            counts[3],
+            counts[4],
+            counts[5],
+            counts[6],
+            counts[0],
+        ];
+    }, [workouts]);
+
+    const typeData = useMemo(() => {
+        const counts: Record<string, number> ={
+            Run: 0,
+            Strength: 0,
+            Other: 0,
+        };
+
+        workouts.forEach((workout) => {
+            if(workout.type === "run") counts.Run += 1;
+            else if(workout.type === "strength") counts.Strength += 1;
+            else counts.Other += 1;
+        });
+
+        return Object.entries(counts).map(([type, count]) => ({
+            type,
+            count,
+        }));
+    }, [workouts]);
+
     return(
         <main className="mx-auto max-w-6xl px-6 py-8">
             <PageHeader title="Progress" subtitle="Review training trends and visualize workout progress over time." />
@@ -44,11 +112,23 @@ export default function ProgressPage(){
             <Section title="Charts">
                 <div className="grid gap-6 lg:grid-cols-2">
                     <Card title="Weekly Activity">
-                        <WeeklyWorkoutsLineChart />
+                        {loading ? (
+                            <p>Loading chart...</p>
+                        ) : error ? (
+                            <p style={{ color: "var (--color-error)" }}>{error}</p>
+                        ) : (
+                            <WeeklyWorkoutsLineChart data={weeklyData} />
+                        )}
                     </Card>
 
                     <Card title="Workout Type Distribution">
-                        <WorkoutTypeBarChart />
+                        {loading ? (
+                            <p>Loading chart...</p>
+                        ) : error ? (
+                            <p style={{ color: "var (--color-error)" }}>{error}</p>
+                        ) : (
+                            <WorkoutTypeBarChart data={typeData} />
+                        )}
                     </Card>
                 </div>
             </Section>

--- a/frontend/components/charts/WeeklyWorkoutsLineChart.tsx
+++ b/frontend/components/charts/WeeklyWorkoutsLineChart.tsx
@@ -2,29 +2,38 @@
 
 import * as d3 from "d3";
 
-type WeeklyWorkoutPoint = {
+export type WeeklyWorkoutPoint = {
     day: string;
     count: number;
 };
 
-const mockData: WeeklyWorkoutPoint[] = [
-    { day: "Mon", count: 1 },
-    { day: "Tue", count: 0 },
-    { day: "Wed", count: 2 },
-    { day: "Thu", count: 1 },
-    { day: "Fri", count: 3 },
-    { day: "Sat", count: 2 },
-    { day: "Sun", count: 1 },
-];
+type Props = {
+    data: WeeklyWorkoutPoint[];
+};
 
-export default function WeeklyWorkoutsLineChart(){
+export default function WeeklyWorkoutsLineChart({ data }: Props){
     const width = 600;
     const height = 260;
     const margin = { top: 20, right: 25, bottom: 35, left: 35 };
-    const xScale = d3.scalePoint().domain(mockData.map((d) => d.day)).range([margin.left, width - margin.right]);
-    const yScale = d3.scaleLinear().domain([0, d3.max(mockData, (d) => d.count) ?? 0]).range([height - margin.bottom, margin.top]);
-    const line = d3.line<WeeklyWorkoutPoint>().x((d) => xScale(d.day) ?? 0).y((d) => yScale(d.count)).curve(d3.curveMonotoneX);
-    const pathData = line(mockData);
+
+    const xScale = d3
+        .scalePoint()
+        .domain(data.map((d) => d.day))
+        .range([margin.left, width - margin.right]);
+    
+    const yScale = d3
+        .scaleLinear()
+        .domain([0, d3.max(data, (d) => d.count) ?? 0])
+        .nice()
+        .range([height - margin.bottom, margin.top]);
+    
+    const line = d3
+        .line<WeeklyWorkoutPoint>()
+        .x((d) => xScale(d.day) ?? 0)
+        .y((d) => yScale(d.count))
+        .curve(d3.curveMonotoneX);
+
+    const pathData = line(data);
     const yTicks = yScale.ticks(4);
 
     return(
@@ -57,7 +66,7 @@ export default function WeeklyWorkoutsLineChart(){
                     </g>
                 ))}
 
-                {mockData.map((d) => (
+                {data.map((d) => (
                     <text
                         key={d.day}
                         x={xScale(d.day)}
@@ -79,7 +88,7 @@ export default function WeeklyWorkoutsLineChart(){
                     />
                 )}
 
-                {mockData.map((d) => (
+                {data.map((d) => (
                     <circle
                         key={`${d.day}-${d.count}`}
                         cx={xScale(d.day)}

--- a/frontend/components/charts/WorkoutTypeBarChart.tsx
+++ b/frontend/components/charts/WorkoutTypeBarChart.tsx
@@ -2,23 +2,32 @@
 
 import * as d3 from "d3";
 
-type WorkoutTypePoint = {
+export type WorkoutTypePoint = {
     type: string;
     count: number;
 };
 
-const mockData: WorkoutTypePoint[] = [
-    { type: "Run", count: 5 },
-    { type: "Strength", count: 3 },
-    { type: "Other", count: 2 },
-];
+type Props = {
+    data: WorkoutTypePoint[];
+};
 
-export default function WorkoutTypeBarChart(){
+export default function WorkoutTypeBarChart({ data }: Props){
     const width = 600;
     const height = 260;
     const margin = { top: 20, right: 25, bottom: 40, left: 40 };
-    const xScale = d3.scaleBand().domain(mockData.map((d) => d.type)).range([margin.left, width - margin.right]).padding(0.3);
-    const yScale = d3.scaleLinear().domain([0, d3.max(mockData, (d) => d.count) ?? 0]).nice().range([height - margin.bottom, margin.top]);
+
+    const xScale = d3
+        .scaleBand()
+        .domain(data.map((d) => d.type))
+        .range([margin.left, width - margin.right])
+        .padding(0.3);
+        
+    const yScale = d3
+        .scaleLinear()
+        .domain([0, d3.max(data, (d) => d.count) ?? 0])
+        .nice()
+        .range([height - margin.bottom, margin.top]);
+
     const yTicks = yScale.ticks(4);
 
     return(
@@ -51,7 +60,7 @@ export default function WorkoutTypeBarChart(){
                     </g>
                 ))}
 
-                {mockData.map((d) => {
+                {data.map((d) => {
                     const x = xScale(d.type) ?? 0;
                     const barWidth = xScale.bandwidth();
                     const y = yScale(d.count);


### PR DESCRIPTION
Closes #48:
- Progress page calls getWorkouts()
- Both charts use fetched workout data
- Mock chart data is removed
- Loading/error states display
- Newly logged workouts affect the charts after visiting Progress Page